### PR TITLE
fix docker image builds for new travis repo

### DIFF
--- a/travis-docker-build.sh
+++ b/travis-docker-build.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
 
-# read current job log after a short delay
-sleep 10s
-curl -m 30 -s "https://api.travis-ci.org/v3/job/${TRAVIS_JOB_ID}/log.txt?deansi=true" > travis_output.log
-
 # get lucee version
-LUCEE_VERSION=$(grep -oP "(?<=\[INFO\] Building Lucee Loader Build )(\d+\.\d+\.\d+\.\d+([-a-zA-Z]*))" travis_output.log)
+LUCEE_VERSION=$(<buildVersionNumber.txt)
 
 # build the travis request body
 function build_request {
@@ -35,4 +31,4 @@ curl -m 30 -s -X POST \
   -H "Travis-API-Version: 3" \
   -H "Authorization: token ${TRAVIS_TOKEN}" \
   -d "${REQUEST_BODY}" \
-  https://api.travis-ci.org/repo/lucee%2Flucee-dockerfiles/requests
+  https://api.travis-ci.com/repo/lucee%2Flucee-dockerfiles/requests


### PR DESCRIPTION
This change removes the dependency on the old lucee/Lucee Travis Build Jobs for the version number, and updates the build trigger API call to use the new lucee/lucee-dockerfiles repo on travis-ci.com 